### PR TITLE
Add progressively enhanced dynamic update of mark as read/not read buttons

### DIFF
--- a/components/BookList.tsx
+++ b/components/BookList.tsx
@@ -2,7 +2,10 @@ import { Book, Status } from '@prisma/client'
 import { clsx } from 'clsx'
 import { useState } from 'react'
 
-export type BookListBook = Pick<Book, 'id' | 'title' | 'author' | 'status'>
+export type BookListBook = Pick<
+  Book,
+  'id' | 'updatedAt' | 'title' | 'author' | 'status'
+>
 export function BookList({ initialBooks }: { initialBooks: BookListBook[] }) {
   const [books, setBooks] = useState<BookListBook[]>(initialBooks)
   return (
@@ -31,23 +34,21 @@ export function BookList({ initialBooks }: { initialBooks: BookListBook[] }) {
                   method: form.method,
                   headers: new Headers({ 'Content-Type': 'application/json' }),
                   body: JSON.stringify({
+                    updatedAt: book.updatedAt,
                     status: newStatus,
                   }),
                 }
 
                 ;(async () => {
                   const r = await fetch(form.action, options)
+                  const updatedBook = await r.json()
 
                   if (r.ok) {
-                    setBooks((booksInner) => {
-                      return booksInner.map((bookInner) => {
-                        const data: BookListBook = {
-                          ...bookInner,
-                        }
-                        if (book.id === bookInner.id) data.status = newStatus
-                        return data
-                      })
-                    })
+                    setBooks((booksInner) =>
+                      booksInner.map((bookInner) =>
+                        book.id === bookInner.id ? updatedBook : bookInner
+                      )
+                    )
                   } else {
                     console.error(`Error when changing book read status`)
                   }

--- a/components/BookList.tsx
+++ b/components/BookList.tsx
@@ -39,11 +39,16 @@ function BookListItem({
   book: BookListBook
   onBookChange: (book: BookListBook) => void
 }) {
+  const [isUpdatePending, setIsUpdatePending] = useState(false)
+
   async function markBookReadOrUnread(
     book: BookListBook,
     e: FormEvent<HTMLFormElement>
   ) {
     e.preventDefault()
+
+    setIsUpdatePending(true)
+
     const form = e.currentTarget
     const data = new FormData(form)
     const newStatus = data.get('status') as Status
@@ -64,6 +69,8 @@ function BookListItem({
     } else {
       console.error(`Error when changing book read status`)
     }
+
+    setIsUpdatePending(false)
   }
 
   return (
@@ -87,7 +94,10 @@ function BookListItem({
           name="status"
           value={book.status === Status.READ ? Status.NOT_READ : Status.READ}
         />
-        <button className="rounded-full bg-black px-2 py-1 text-white">
+        <button
+          className="rounded-full bg-black px-2 py-1 text-white disabled:opacity-50"
+          disabled={isUpdatePending}
+        >
           {book.status === Status.READ ? 'Mark as un-read' : 'Mark as read'}
         </button>
       </form>

--- a/components/BookList.tsx
+++ b/components/BookList.tsx
@@ -20,6 +20,28 @@ export function BookList({ books }: { books: BookListBook[] }) {
               action={`/api/book/${book.id}`}
               method="post"
               className="col-start-2 row-span-2"
+              onSubmit={(e) => {
+                e.preventDefault()
+                const form = e.currentTarget
+                const data = new FormData(form)
+                const options = {
+                  method: form.method,
+                  headers: new Headers({ 'Content-Type': 'application/json' }),
+                  body: JSON.stringify({
+                    status: data.get('status'),
+                  }),
+                }
+
+                ;(async () => {
+                  const r = await fetch(form.action, options)
+
+                  if (!r.ok) {
+                    console.error(`Error when changing book read status`)
+                    return
+                  }
+                  console.log(data)
+                })()
+              }}
             >
               <input
                 type="hidden"

--- a/components/BookList.tsx
+++ b/components/BookList.tsx
@@ -8,7 +8,7 @@ export function BookList({ books }: { books: BookListBook[] }) {
       <ul>
         {books.map((book) => (
           <li
-            key={book.title}
+            key={book.id}
             className="grid grid-cols-[1fr_auto] grid-rows-2 items-center p-4"
           >
             <div className="col-start-1 row-start-1 text-lg">{book.title}</div>

--- a/components/BookList.tsx
+++ b/components/BookList.tsx
@@ -10,6 +10,35 @@ export type BookListBook = Pick<
 export function BookList({ initialBooks }: { initialBooks: BookListBook[] }) {
   const [books, setBooks] = useState<BookListBook[]>(initialBooks)
 
+  return (
+    <>
+      <ul>
+        {books.map((book) => (
+          <BookListItem
+            key={book.id}
+            book={book}
+            onBookChange={(updatedBook) =>
+              setBooks((booksInner) =>
+                booksInner.map((bookInner) =>
+                  updatedBook.id === bookInner.id ? updatedBook : bookInner
+                )
+              )
+            }
+          />
+        ))}
+      </ul>
+      <AddBook />
+    </>
+  )
+}
+
+function BookListItem({
+  book,
+  onBookChange,
+}: {
+  book: BookListBook
+  onBookChange: (book: BookListBook) => void
+}) {
   async function markBookReadOrUnread(
     book: BookListBook,
     e: FormEvent<HTMLFormElement>
@@ -28,56 +57,41 @@ export function BookList({ initialBooks }: { initialBooks: BookListBook[] }) {
     }
 
     const r = await fetch(form.action, options)
-    const updatedBook = await r.json()
 
     if (r.ok) {
-      setBooks((booksInner) =>
-        booksInner.map((bookInner) =>
-          book.id === bookInner.id ? updatedBook : bookInner
-        )
-      )
+      const updatedBook = await r.json()
+      onBookChange(updatedBook)
     } else {
       console.error(`Error when changing book read status`)
     }
   }
 
   return (
-    <>
-      <ul>
-        {books.map((book) => (
-          <li
-            key={book.id}
-            className="grid grid-cols-[1fr_auto] grid-rows-2 items-center p-4"
-          >
-            <div className="col-start-1 row-start-1 text-lg">{book.title}</div>
-            <div className="col-start-1 row-start-2 text-gray-400">
-              by {book.author}
-            </div>
+    <li
+      key={book.id}
+      className="grid grid-cols-[1fr_auto] grid-rows-2 items-center p-4"
+    >
+      <div className="col-start-1 row-start-1 text-lg">{book.title}</div>
+      <div className="col-start-1 row-start-2 text-gray-400">
+        by {book.author}
+      </div>
 
-            <form
-              action={`/api/book/${book.id}`}
-              method="post"
-              className="col-start-2 row-span-2"
-              onSubmit={(e) => markBookReadOrUnread(book, e)}
-            >
-              <input
-                type="hidden"
-                name="status"
-                value={
-                  book.status === Status.READ ? Status.NOT_READ : Status.READ
-                }
-              />
-              <button className="rounded-full bg-black px-2 py-1 text-white">
-                {book.status === Status.READ
-                  ? 'Mark as un-read'
-                  : 'Mark as read'}
-              </button>
-            </form>
-          </li>
-        ))}
-      </ul>
-      <AddBook />
-    </>
+      <form
+        action={`/api/book/${book.id}`}
+        method="post"
+        className="col-start-2 row-span-2"
+        onSubmit={(e) => markBookReadOrUnread(book, e)}
+      >
+        <input
+          type="hidden"
+          name="status"
+          value={book.status === Status.READ ? Status.NOT_READ : Status.READ}
+        />
+        <button className="rounded-full bg-black px-2 py-1 text-white">
+          {book.status === Status.READ ? 'Mark as un-read' : 'Mark as read'}
+        </button>
+      </form>
+    </li>
   )
 }
 

--- a/components/BookList.tsx
+++ b/components/BookList.tsx
@@ -1,9 +1,10 @@
 import { Book, Status } from '@prisma/client'
 import { clsx } from 'clsx'
 import { useState } from 'react'
+import { BookSerializable } from '@/pages/api/book/[bookid]'
 
 export type BookListBook = Pick<
-  Book,
+  BookSerializable,
   'id' | 'updatedAt' | 'title' | 'author' | 'status'
 >
 export function BookList({ initialBooks }: { initialBooks: BookListBook[] }) {

--- a/components/BookList.tsx
+++ b/components/BookList.tsx
@@ -1,8 +1,10 @@
 import { Book, Status } from '@prisma/client'
 import { clsx } from 'clsx'
+import { useState } from 'react'
 
 export type BookListBook = Pick<Book, 'id' | 'title' | 'author' | 'status'>
-export function BookList({ books }: { books: BookListBook[] }) {
+export function BookList({ initialBooks }: { initialBooks: BookListBook[] }) {
+  const [books, setBooks] = useState<BookListBook[]>(initialBooks)
   return (
     <>
       <ul>
@@ -24,22 +26,31 @@ export function BookList({ books }: { books: BookListBook[] }) {
                 e.preventDefault()
                 const form = e.currentTarget
                 const data = new FormData(form)
+                const newStatus = data.get('status') as Status
                 const options = {
                   method: form.method,
                   headers: new Headers({ 'Content-Type': 'application/json' }),
                   body: JSON.stringify({
-                    status: data.get('status'),
+                    status: newStatus,
                   }),
                 }
 
                 ;(async () => {
                   const r = await fetch(form.action, options)
 
-                  if (!r.ok) {
+                  if (r.ok) {
+                    setBooks((booksInner) => {
+                      return booksInner.map((bookInner) => {
+                        const data: BookListBook = {
+                          ...bookInner,
+                        }
+                        if (book.id === bookInner.id) data.status = newStatus
+                        return data
+                      })
+                    })
+                  } else {
                     console.error(`Error when changing book read status`)
-                    return
                   }
-                  console.log(data)
                 })()
               }}
             >

--- a/pages/api/book.ts
+++ b/pages/api/book.ts
@@ -32,5 +32,6 @@ export default async function handler(
       author,
     },
   })
-  return res.redirect(307, '/dashboard')
+
+  return res.status(200).end()
 }

--- a/pages/api/book/[bookid].ts
+++ b/pages/api/book/[bookid].ts
@@ -48,5 +48,5 @@ export default async function updateBook(
       .send({ message: 'An error occurred while performing the update.' })
   }
 
-  return res.redirect(307, '/')
+  return res.status(200).end()
 }

--- a/pages/api/book/[bookid].ts
+++ b/pages/api/book/[bookid].ts
@@ -1,14 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { getAuth } from '@clerk/nextjs/server'
-import { PrismaClient } from '@prisma/client'
+import { Book, PrismaClient } from '@prisma/client'
+import { ReplaceDateWithStrings } from '@/utils/typeUtils'
+
+export type BookSerializable = ReplaceDateWithStrings<Book>
 
 type Data =
   | {
       message?: string
     }
-  | {
-      // TODO: Book
-    }
+  | BookSerializable
 
 export default async function updateBook(
   req: NextApiRequest,

--- a/pages/finishedBooks.tsx
+++ b/pages/finishedBooks.tsx
@@ -38,7 +38,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
   }
 
   const prisma = new PrismaClient()
-  const books: BookListBook[] = await prisma.book.findMany({
+  const books = await prisma.book.findMany({
     select: {
       id: true,
       updatedAt: true,

--- a/pages/finishedBooks.tsx
+++ b/pages/finishedBooks.tsx
@@ -25,7 +25,7 @@ export default function Dashboard({ books }: { books: BookListBook[] }) {
           },
         }}
       />
-      <BookList books={books} />
+      <BookList initialBooks={books} />
     </main>
   )
 }

--- a/pages/finishedBooks.tsx
+++ b/pages/finishedBooks.tsx
@@ -41,6 +41,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
   const books: BookListBook[] = await prisma.book.findMany({
     select: {
       id: true,
+      updatedAt: true,
       title: true,
       author: true,
       status: true,
@@ -53,7 +54,10 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
 
   return {
     props: {
-      books,
+      books: books.map((book) => ({
+        ...book,
+        updatedAt: book.updatedAt.toISOString(),
+      })),
       ...buildClerkProps(req),
     },
   }

--- a/pages/readingList.tsx
+++ b/pages/readingList.tsx
@@ -38,7 +38,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
   }
 
   const prisma = new PrismaClient()
-  const books: BookListBook[] = await prisma.book.findMany({
+  const books = await prisma.book.findMany({
     select: {
       id: true,
       updatedAt: true,

--- a/pages/readingList.tsx
+++ b/pages/readingList.tsx
@@ -41,6 +41,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
   const books: BookListBook[] = await prisma.book.findMany({
     select: {
       id: true,
+      updatedAt: true,
       title: true,
       author: true,
       status: true,
@@ -53,7 +54,10 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
 
   return {
     props: {
-      books,
+      books: books.map((book) => ({
+        ...book,
+        updatedAt: book.updatedAt.toISOString(),
+      })),
       ...buildClerkProps(req),
     },
   }

--- a/pages/readingList.tsx
+++ b/pages/readingList.tsx
@@ -25,7 +25,7 @@ export default function ReadingList({ books }: { books: BookListBook[] }) {
           },
         }}
       />
-      <BookList books={books} />
+      <BookList initialBooks={books} />
     </main>
   )
 }

--- a/utils/typeUtils.ts
+++ b/utils/typeUtils.ts
@@ -1,0 +1,6 @@
+// Helper type to replace Date with string on a type.
+// Useful because we need to convert the Date's on our Primsa types to strings
+// so we can return them from our Next.js route handlers without error.
+export type ReplaceDateWithStrings<T> = {
+  [K in keyof T]: T[K] extends Date ? string : T[K]
+}


### PR DESCRIPTION
- By default changing book read status uses a standard form POST. This progressively enhances it to use `fetch` and perform the request in the background. The button disabled while fetch is pending and books update their read/non-read status appropriately.
- Currently not removing the book from the list when marked as read, as this allows you to mark it as un-read again if you made a mistake, but we could do this.
- Added in optimistic currency control for DB updates for `/book/[bookid]` endpoint.
  - Did this requiring `updatedBy` is passed when updating books, and if it doesn't match the latest version the update request is denied.
    - As part of this needed to return `updatedBy` to client. Can't serialise date with Next.js API routes out of the box, so `toISOString()` them manually. Used a type helper to get right return type for the API route from the Prisma type.
- Currently no error reporting client side, this needs adding in.