### PR TITLE
Logo tweaks

### DIFF
--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -52,7 +52,7 @@ export function HomepageLogo() {
         whileTap={{ scale: 0.9 }}
       >
         <MotionImage
-          className="max-w-[50vw]"
+          className="max-w-[50vw] py-2"
           src="/android-chrome-512x512.png"
           alt="My books logo"
           width={250}

--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -47,6 +47,7 @@ export function HomepageLogo() {
         alt="My books logo"
         width={250}
         height={250}
+        priority={true}
       />
     </MotionLink>
   )

--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -8,7 +8,7 @@ const getLogoGradient = (
   stop3: number,
   stop4: number
 ) =>
-  `radial-gradient(
+  `radial-gradient(circle, 
   hsla(53, 82%, 58%, 1) ${stop1}%, 
   hsla(53, 84%, 74%, 1) ${stop2}%, 
   hsla(53, 100%, 91%, 1) ${stop3}%, 

--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -31,7 +31,7 @@ export function HomepageLogo() {
 
   return (
     <motion.div
-      className="fixed inset-0 m-auto flex items-center justify-center"
+      className="pointer-events-none fixed inset-0 m-auto flex items-center justify-center"
       initial={initialLogoAnimation}
       animate={isBookHovering ? hoverLogoAnimation : undefined}
       // whileFocus={hoverLogoAnimation}
@@ -44,7 +44,7 @@ export function HomepageLogo() {
         },
       }}
     >
-      <Link href="/readingList">
+      <Link href="/readingList" className="pointer-events-auto">
         <MotionImage
           className="max-w-[50vw]"
           src="/android-chrome-512x512.png"

--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import { motion } from 'framer-motion'
 import Link from 'next/link'
+import { useState } from 'react'
 
 const getLogoGradient = (
   stop1: number,
@@ -23,14 +24,19 @@ const hoverLogoAnimation = {
 }
 
 const MotionLink = motion(Link)
+const MotionImage = motion(Image)
 export function HomepageLogo() {
+  const [isBookHovering, setIsBookHovering] = useState(false)
+  console.log(isBookHovering)
+
   return (
     <MotionLink
       className="fixed inset-0 m-auto flex items-center justify-center"
       href="/readingList"
       initial={initialLogoAnimation}
-      whileHover={hoverLogoAnimation}
-      whileFocus={hoverLogoAnimation}
+      animate={isBookHovering ? hoverLogoAnimation : undefined}
+      // whileHover={hoverLogoAnimation}
+      // whileFocus={hoverLogoAnimation}
       whileTap={{ scale: 0.9 }}
       transition={{
         type: 'spring',
@@ -41,10 +47,15 @@ export function HomepageLogo() {
         },
       }}
     >
-      <Image
+      <MotionImage
         className="max-w-[50vw]"
         src="/android-chrome-512x512.png"
         alt="My books logo"
+        onHoverStart={(e) => setIsBookHovering(true)}
+        onHoverEnd={(e) => setIsBookHovering(false)}
+        onFocus={(e) => {
+          console.log('focus', e)
+        }}
         width={250}
         height={250}
         priority={true}

--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -32,7 +32,10 @@ export function HomepageLogo() {
     <motion.div
       className="pointer-events-none fixed inset-0 m-auto flex items-center justify-center"
       initial={initialLogoAnimation}
-      animate={isBookHovering ? hoverLogoAnimation : undefined}
+      animate={
+        // On touch devices you can't really hover, so in that case just always apply the animation
+        isTouchDevice() || isBookHovering ? hoverLogoAnimation : undefined
+      }
       transition={{
         type: 'spring',
         bounce: 0.5,
@@ -61,5 +64,15 @@ export function HomepageLogo() {
         />
       </MotionLink>
     </motion.div>
+  )
+}
+
+function isTouchDevice() {
+  if (typeof window === 'undefined') return false // Handle SSG/SSR
+  return (
+    'ontouchstart' in window ||
+    navigator.maxTouchPoints > 0 ||
+    // @ts-ignore
+    navigator.msMaxTouchPoints > 0
   )
 }

--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -36,6 +36,7 @@ export function HomepageLogo() {
         // On touch devices you can't really hover, so in that case just always apply the animation
         isTouchDevice() || isBookHovering ? hoverLogoAnimation : undefined
       }
+      whileTap={{ scale: 0.9 }}
       transition={{
         type: 'spring',
         bounce: 0.5,
@@ -52,7 +53,7 @@ export function HomepageLogo() {
         onHoverEnd={() => setIsBookHovering(false)}
         onFocus={() => setIsBookHovering(true)}
         onBlur={() => setIsBookHovering(false)}
-        whileTap={{ scale: 0.9 }}
+        whileTap={{ scale: 0.8 }}
       >
         <MotionImage
           className="max-w-[50vw] py-2"

--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -35,7 +35,7 @@ export function HomepageLogo() {
       transition={{
         type: 'spring',
         bounce: 0.5,
-        duration: 1.5,
+        duration: 1.2,
         backgroundImage: {
           duration: 0.6,
         },

--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -12,7 +12,7 @@ const getLogoGradient = (
   hsla(53, 82%, 58%, 1) ${stop1}%, 
   hsla(53, 84%, 74%, 1) ${stop2}%, 
   hsla(53, 100%, 91%, 1) ${stop3}%, 
-  hsla(0, 0%, 100%, 1)  ${stop4}%
+  transparent  ${stop4}%
 )`
 const initialLogoAnimation = {
   backgroundImage: getLogoGradient(0, 15, 25, 35),
@@ -26,7 +26,7 @@ const MotionLink = motion(Link)
 export function HomepageLogo() {
   return (
     <MotionLink
-      className="p-[100px]"
+      className="fixed inset-0 m-auto flex items-center justify-center"
       href="/readingList"
       initial={initialLogoAnimation}
       whileHover={hoverLogoAnimation}

--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -30,9 +30,8 @@ export function HomepageLogo() {
   console.log(isBookHovering)
 
   return (
-    <MotionLink
+    <motion.div
       className="fixed inset-0 m-auto flex items-center justify-center"
-      href="/readingList"
       initial={initialLogoAnimation}
       animate={isBookHovering ? hoverLogoAnimation : undefined}
       // whileHover={hoverLogoAnimation}
@@ -47,19 +46,21 @@ export function HomepageLogo() {
         },
       }}
     >
-      <MotionImage
-        className="max-w-[50vw]"
-        src="/android-chrome-512x512.png"
-        alt="My books logo"
-        onHoverStart={(e) => setIsBookHovering(true)}
-        onHoverEnd={(e) => setIsBookHovering(false)}
-        onFocus={(e) => {
-          console.log('focus', e)
-        }}
-        width={250}
-        height={250}
-        priority={true}
-      />
-    </MotionLink>
+      <Link href="/readingList">
+        <MotionImage
+          className="max-w-[50vw]"
+          src="/android-chrome-512x512.png"
+          alt="My books logo"
+          onHoverStart={() => setIsBookHovering(true)}
+          onHoverEnd={() => setIsBookHovering(false)}
+          onFocus={(e) => {
+            console.log('focus', e)
+          }}
+          width={250}
+          height={250}
+          priority={true}
+        />
+      </Link>
+    </motion.div>
   )
 }

--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -27,14 +27,12 @@ const MotionLink = motion(Link)
 const MotionImage = motion(Image)
 export function HomepageLogo() {
   const [isBookHovering, setIsBookHovering] = useState(false)
-  console.log(isBookHovering)
 
   return (
     <motion.div
       className="pointer-events-none fixed inset-0 m-auto flex items-center justify-center"
       initial={initialLogoAnimation}
       animate={isBookHovering ? hoverLogoAnimation : undefined}
-      // whileFocus={hoverLogoAnimation}
       transition={{
         type: 'spring',
         bounce: 0.5,
@@ -44,22 +42,24 @@ export function HomepageLogo() {
         },
       }}
     >
-      <Link href="/readingList" className="pointer-events-auto">
+      <MotionLink
+        href="/readingList"
+        className="pointer-events-auto"
+        onHoverStart={() => setIsBookHovering(true)}
+        onHoverEnd={() => setIsBookHovering(false)}
+        onFocus={() => setIsBookHovering(true)}
+        onBlur={() => setIsBookHovering(false)}
+        whileTap={{ scale: 0.9 }}
+      >
         <MotionImage
           className="max-w-[50vw]"
           src="/android-chrome-512x512.png"
           alt="My books logo"
-          onHoverStart={() => setIsBookHovering(true)}
-          onHoverEnd={() => setIsBookHovering(false)}
-          whileTap={{ scale: 0.9 }}
-          onFocus={(e) => {
-            console.log('focus', e)
-          }}
           width={250}
           height={250}
           priority={true}
         />
-      </Link>
+      </MotionLink>
     </motion.div>
   )
 }

--- a/components/HomepageLogo.tsx
+++ b/components/HomepageLogo.tsx
@@ -34,9 +34,7 @@ export function HomepageLogo() {
       className="fixed inset-0 m-auto flex items-center justify-center"
       initial={initialLogoAnimation}
       animate={isBookHovering ? hoverLogoAnimation : undefined}
-      // whileHover={hoverLogoAnimation}
       // whileFocus={hoverLogoAnimation}
-      whileTap={{ scale: 0.9 }}
       transition={{
         type: 'spring',
         bounce: 0.5,
@@ -53,6 +51,7 @@ export function HomepageLogo() {
           alt="My books logo"
           onHoverStart={() => setIsBookHovering(true)}
           onHoverEnd={() => setIsBookHovering(false)}
+          whileTap={{ scale: 0.9 }}
           onFocus={(e) => {
             console.log('focus', e)
           }}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -27,7 +27,7 @@ export default function Home() {
           content="Manage yours books - the books you want to read, or the books you've already read."
         />
       </Head>
-      <h1 className="invisible mt-12 text-2xl">My books</h1>
+      <h1 className="mt-12 text-2xl">My books</h1>
       <HomepageLogo />
     </main>
   )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,7 @@ const inter = Inter({ subsets: ['latin'] })
 export default function Home() {
   return (
     <main
-      className={`${inter.className} flex h-[100dvh] flex-col items-center justify-center overflow-hidden`}
+      className={`${inter.className} flex h-[100dvh] flex-col items-center`}
     >
       <Head>
         <title>My books</title>


### PR DESCRIPTION
- Re-added h1 behind gradient so it's visible. Gradient made transparent to achieve this.
- Fixed gradient so it's always a circle and not distorted by screen size.
- Have the animation apply when the book itself is hovered, not when the wrapping element providing the gradient is hovered.
- Changed the gradient so it applies to the whole screen rather than a fixed padding around the book.
- Have touch devices just apply the animation on load, as you can't hover well on touch.
