### PR TITLE
Cache images for one hour.

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,9 @@ await import("./env/env.mjs");
 const nextConfig = {
   reactStrictMode: true,
   images: {
+    images: {
+      minimumCacheTTL: 60 * 60, // Cache images for 1 hour
+    },
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
Increase from default of 60 seconds.

We generate unique names for our images on upload, so changing the image will result in a new name anyway, so we shouldn't have caching issues for our cover image.

The placeholder image would likely be in the cache for an hour though.